### PR TITLE
Update package.json. Change whitespace regex.

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
                 },
                 "AllAutocomplete.whitespace": {
                     "type": "string",
-                    "default": "[^\\w]+",
+                    "default": "[^\\w-_]+",
                     "description": "All Autocomplete: Regex to use for splitting whitespace"
                 },
                 "AllAutocomplete.cycleOpenDocumentsOnLaunch": {


### PR DESCRIPTION
Change default AllAutocomplete.whitespace to "[^\\w-_]+". 
In default you beautiful plugin don't see css variables starting with dash (example: --main-color: black) and python variables with undersope (example: default_naming_for_python).